### PR TITLE
Ensure color picker is removed after use

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -90,11 +90,13 @@ document.addEventListener("DOMContentLoaded", function() {
 	document.querySelectorAll(".key span").forEach(span => {        
 	    span.addEventListener('click', function() {
             
-	        let colorInput = document.createElement('input');
-	        colorInput.type = 'color';
-	        colorInput.value = this.style.backgroundColor;
-			
-	        colorInput.addEventListener('input', (event) => {
+                let colorInput = document.createElement('input');
+                colorInput.type = 'color';
+                colorInput.value = this.style.backgroundColor;
+
+                document.body.appendChild(colorInput);
+                colorInput.addEventListener('change', () => colorInput.remove());
+                colorInput.addEventListener('input', (event) => {
                 
 	            let newColor = event.target.value;
 	            let entityType = this.parentElement.textContent.trim();


### PR DESCRIPTION
## Summary
- append color input to the DOM before showing it
- remove color input on change so temporary element doesn't remain

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68404b8920388328950745536e63d7e1