### PR TITLE
Add npm start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ SpacyVis/
 
 3. Run the server:
    ```bash
-   node server.js
+   npm start
    ```
 4. Access the app at:
    ```
@@ -50,7 +50,7 @@ SpacyVis/
    ```
 
 ## Usage
-1. Start the server by running `node server.js`.
+1. Start the server by running `npm start`.
 2. Upload XML files by selecting a file and clicking "Upload & Visualize!".
 3. Hover over words to see detailed attributes in the sidebar.
 4. Click entity color blocks to adjust the color representation.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add start script to package.json
- document `npm start` usage in setup and usage sections of README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68404b8704008328945ab6173441d756