### PR TITLE
Add reusable color utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
-  "node server.js"
-  "test": "mocha"
+    "start": "node server.js",
+    "test": "mocha"
   },
   "keywords": [],
   "author": "",

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,3 +1,5 @@
+import { getRandomColor, isColorDark } from '../utils/color.js';
+
 const dataAttributeLabels = {
     pos:            'part of speech',
     entType:        'type',
@@ -27,13 +29,6 @@ const dataAttributeLabels = {
     likeNum:        'like number',
     likeUrl:        'like url',
 };
-
-function isColorDark(hex) {
-    const r = parseInt(hex.substring(1, 3), 16);
-    const g = parseInt(hex.substring(3, 5), 16);
-    const b = parseInt(hex.substring(5, 7), 16);
-    return 0.299 * r + 0.587 * g + 0.114 * b < 128;    
-}
 
 function adjustMainBody() {
     const headerHeight = document.querySelector('.header').offsetHeight;

--- a/server.js
+++ b/server.js
@@ -1,12 +1,19 @@
-const express = require('express');
-const multer = require('multer');
-const xml2js = require('xml2js');
-const path = require('path');
+import express from 'express';
+import multer from 'multer';
+import xml2js from 'xml2js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import { getRandomColor, isColorDark } from './utils/color.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const app = express();
 const port = process.env.PORT || 3000;
 
 app.use(express.static(path.join(__dirname, 'public')));
+app.use('/utils', express.static(path.join(__dirname, 'utils')));
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');
 
@@ -24,22 +31,6 @@ const upload = multer({
         }
     }
 });
-
-function getRandomColor() {
-    const letters = '0123456789ABCDEF';
-    let color = '#';
-    for (let i = 0; i < 6; i++) {
-        color += letters[Math.floor(Math.random() * 16)];
-    }
-    return color;
-}
-
-function isColorDark(hex) {
-    const r = parseInt(hex.substring(1, 3), 16);
-    const g = parseInt(hex.substring(3, 5), 16);
-    const b = parseInt(hex.substring(5, 7), 16);
-    return 0.299 * r + 0.587 * g + 0.114 * b < 128;    
-}
 
 
 app.get('/', (req, res) => {
@@ -102,10 +93,10 @@ app.post('/upload', (req, res) => {
     });
 });
 
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
     app.listen(port, () => {
         console.log(`Server running at http://localhost:${port}/`);
     });
 }
 
-module.exports = app;
+export default app;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,7 +1,7 @@
-const request = require('supertest');
-const { expect } = require('chai');
-const path = require('path');
-const app = require('../server');
+import request from 'supertest';
+import { expect } from 'chai';
+import path from 'path';
+import app from '../server.js';
 
 describe('POST /upload', function() {
   it('should respond with 200 for a valid upload', function(done) {

--- a/utils/color.js
+++ b/utils/color.js
@@ -1,0 +1,15 @@
+export function getRandomColor() {
+    const letters = '0123456789ABCDEF';
+    let color = '#';
+    for (let i = 0; i < 6; i++) {
+        color += letters[Math.floor(Math.random() * 16)];
+    }
+    return color;
+}
+
+export function isColorDark(hex) {
+    const r = parseInt(hex.substring(1, 3), 16);
+    const g = parseInt(hex.substring(3, 5), 16);
+    const b = parseInt(hex.substring(5, 7), 16);
+    return 0.299 * r + 0.587 * g + 0.114 * b < 128;
+}

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -8,8 +8,7 @@
     <title>Upload and Visualize XML</title>
     <link rel="stylesheet" 
           href="/css/styles.css">    
-    <script src="/js/index.js" 
-            defer></script>
+    <script type="module" src="/js/index.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- create `utils/color.js` with `getRandomColor` and `isColorDark`
- convert server and test suite to ES modules
- reuse new color helpers in both the server and client
- load client script as an ES module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840c29deaa4832893ab8a38dc1c1e45