### PR TITLE
Fix package-lock handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.log
 node_modules/
-package-lock.json


### PR DESCRIPTION
## Summary
- keep `package-lock.json` under version control
- stop ignoring `package-lock.json`

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840c29c8ff48328bb29cf097b6eae0a