### PR TITLE
Add tests for color utilities and XML error handling

### DIFF
--- a/test/color.test.js
+++ b/test/color.test.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { getRandomColor, isColorDark } from '../utils/color.js';
+
+describe('color utilities', function() {
+  describe('getRandomColor', function() {
+    it('should return a valid hex color string', function() {
+      const color = getRandomColor();
+      expect(color).to.match(/^#[0-9A-F]{6}$/);
+    });
+
+    it('should generate varying colors', function() {
+      const colors = new Set(Array.from({ length: 5 }, getRandomColor));
+      expect(colors.size).to.be.greaterThan(1);
+    });
+  });
+
+  describe('isColorDark', function() {
+    it('should identify dark colors', function() {
+      expect(isColorDark('#000000')).to.be.true;
+    });
+
+    it('should identify light colors', function() {
+      expect(isColorDark('#FFFFFF')).to.be.false;
+    });
+  });
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -29,4 +29,12 @@ describe('POST /upload', function() {
       .expect(400)
       .expect('No file uploaded', done);
   });
+
+  it('should respond with 500 when XML is malformed', function(done) {
+    request(app)
+      .post('/upload')
+      .attach('xmlfile', Buffer.from('<document><word value="hi"></document>'), 'test.xml')
+      .expect(500)
+      .expect('Unable to parse XML', done);
+  });
 });


### PR DESCRIPTION
## Summary
- add unit tests for `getRandomColor` and `isColorDark`
- expand `/upload` tests to cover malformed XML upload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d64e1711083288f3c54429ca43f67