### PR TITLE
Fix README repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ SpacyVis/
 ### Setup
 1. Clone the repository:
    ```bash
-   git clone https://github.com/username/spacyvis.git
+   git clone https://github.com/username/spacyvis.git # example repository URL
    cd spacyvis
    ```
 2. Install dependencies:


### PR DESCRIPTION
## Summary
- mark repository URL as an example so users know to replace it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d64dd6d288328934dabdaaea16014